### PR TITLE
Adds custom install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ defaults, and so on. Tweak this script, and occasionally run `dot` from
 time to time to keep your environment fresh and up-to-date. You can find
 this script in `bin/`.
 
+## custom install
+
+If you are using an alternative shell like fish, or alternative version manager software like asdf, some of the commands might not be a good fit for you. You might also want to ignore certain aliases or osx configuration changes to fit your preferences. As a bare minimum you will need to have the `.dotfiles/bin` files in your path to set up a lot of repositories. You can accomplish this by cloning the repository and using whatever method your shell supports to add that folder to your path, for example `fish_add_path .dotfiles/bin`. You might also need some of the workarounds like the ones for mysql described in `ruby/install.sh`.
+
 ## topical
 
 Everything's built around topic areas. If you're adding a new area to your


### PR DESCRIPTION
Adds a section with some info for people not using zsh or for those who want to use a version manager like asdf/rbenv/nvm/etc instead of the tools in dotfiles, but still need features like the scripts in `/bin`