### PR TITLE
Update pryrc.symlink

### DIFF
--- a/system/pryrc.symlink
+++ b/system/pryrc.symlink
@@ -1,4 +1,4 @@
 ["~/.irbrc", "~/.pryrc.local"].each do |file|
   path = File.expand_path file
-  load path if File.exists?(path)
+  load path if File.exist?(path)
 end


### PR DESCRIPTION
File.exists? was deprecated in Ruby 2.1 and removed in Ruby 3.2. 