### PR TITLE
Add uat as a valid environment

### DIFF
--- a/bin/ssm-connect
+++ b/bin/ssm-connect
@@ -14,7 +14,7 @@ readonly REQUIRED_COMMANDS=("aws" "awk" "pgrep" "pkill" "jq")
 readonly DEFAULT_CONNECTION_METHOD="connect"
 
 # Valid environments and their AWS account mappings
-readonly VALID_ENVIRONMENTS=("staging" "production" "management")
+readonly VALID_ENVIRONMENTS=("staging" "production" "management" "uat")
 
 # Helper functions to get account info (compatible with older bash)
 get_environment_account() {
@@ -22,6 +22,7 @@ get_environment_account() {
         "staging") echo "086920961728" ;;
         "production") echo "086962800241" ;;
         "management") echo "073638633986" ;;
+        "uat") echo "086962800241" ;;
         *) return 1 ;;
     esac
 }


### PR DESCRIPTION
Before change:
```bash
ssm-connect nomad-server-uat uat tunnel 4646 4646
[ERROR] Unknown environment: uat
```

After change:
```bash
bin/ssm-connect nomad-server-uat uat tunnel 4646 4646
[INFO] Creating port forwarding tunnel...
[INFO] Local port 4646 -> Remote port 4646
[INFO] Searching for instance: Name=nomad-server-uat, Environment=uat
[WARN] Multiple instances found (       3):
[WARN]   - i-0f934843e7df3c890
[WARN]   - i-0cafddee6587d43a0
[WARN]   - i-0602091349e89e704
[INFO] Using the first instance: i-0f934843e7df3c890
[INFO] Creating tunnel to instance: i-0f934843e7df3c890
[INFO] Cleaning up existing tunnels for nomad-server-uat (uat)...

Starting session with SessionId: botocore-session-1780087039-v4zo3xqf3bg62fqggldyuifza8
Port 4646 opened for sessionId botocore-session-1780087039-v4zo3xqf3bg62fqggldyuifza8.
Waiting for connections...
```

https://app.clickup.com/t/9014033846/86ba6wz8x