### PR TITLE
PR2D: infra/ topic — Terraform quality toolchain + ansible

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -4,6 +4,7 @@
 
 tap "homebrew/bundle"
 tap "homebrew/services"
+tap "terraform-linters/tap"
 
 # Text editors
 brew "ctags-exuberant"
@@ -60,6 +61,15 @@ brew "consul"
 brew "nomad"
 brew "vault"
 brew "tfenv"
+brew "packer"
+
+# Infrastructure quality (Terraform lint/security/docs + pre-commit + ansible)
+brew "pre-commit"
+brew "terraform-linters/tap/tflint"
+brew "tfsec"
+brew "trivy"
+brew "terraform-docs"
+brew "ansible"
 
 # Databases
 brew "mysql@5.7"

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+#
+# Infrastructure quality toolchain (see docs/package-matrix.md): the Terraform
+# lint/security/docs tools the repos drive through pre-commit, plus ansible.
+# Independently runnable and safe to re-run. On Linux it depends on pipx (from
+# python/install.sh) for pre-commit and ansible.
+#
+# Packer is NOT here — it comes from the HashiCorp apt repo in
+# script/packages/ubuntu.sh (Linux) and the Brewfile (macOS).
+
+set -e
+
+OS="$(uname)"
+ANSIBLE_VERSION=2.18.7          # floor from ansible-ke
+TERRAFORM_DOCS_VERSION=0.19.0   # no apt/installer-script; pinned release tarball
+
+# pre-commit (latest) and ansible (pinned) via pipx. Idempotent.
+install_pipx_tools() {
+  if ! command -v pipx >/dev/null 2>&1; then
+    echo "infra/install.sh: pipx not found — run python/install.sh first" >&2
+    exit 1
+  fi
+  pipx install pre-commit 2>/dev/null || pipx upgrade pre-commit || true
+  pipx install "ansible==${ANSIBLE_VERSION}" 2>/dev/null \
+    || pipx install --force "ansible==${ANSIBLE_VERSION}" || true
+}
+
+if [[ "$OS" == "Darwin" ]]; then
+  # macOS: declared in the Brewfile and installed by `brew bundle`. Install
+  # defensively so this topic is runnable on its own.
+  if command -v brew >/dev/null 2>&1; then
+    brew install tflint tfsec trivy terraform-docs packer pre-commit ansible
+  else
+    echo "infra/install.sh: Homebrew missing; run homebrew/install.sh first" >&2
+    exit 1
+  fi
+
+elif [[ "$OS" == "Linux" ]]; then
+  arch="$(dpkg --print-architecture)"   # amd64 | arm64
+
+  # tflint, tfsec, trivy: official install scripts (fetch latest, install to
+  # /usr/local/bin). These are remote-script pipes — the documented install path.
+  curl -fsSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+    | sudo sh -s -- -b /usr/local/bin
+
+  # terraform-docs: pinned release tarball -> /usr/local/bin.
+  tmp="$(mktemp -d)"
+  curl -fsSL "https://terraform-docs.io/dl/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-${arch}.tar.gz" \
+    -o "${tmp}/terraform-docs.tar.gz"
+  tar -xzf "${tmp}/terraform-docs.tar.gz" -C "$tmp" terraform-docs
+  sudo install -m 0755 "${tmp}/terraform-docs" /usr/local/bin/terraform-docs
+  rm -rf "$tmp"
+
+  install_pipx_tools
+
+else
+  echo "infra/install.sh: unsupported OS '$OS'" >&2
+  exit 1
+fi

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -11,18 +11,21 @@
 set -e
 
 OS="$(uname)"
-ANSIBLE_VERSION=2.18.7          # floor from ansible-ke
+# ansible-ke pins "ansible@2.18.7" — that's the ansible-CORE version (the engine).
+# The PyPI `ansible` bundle uses different numbers (9.x/10.x/…), so pin ansible-core.
+ANSIBLE_CORE_VERSION=2.18.7
 TERRAFORM_DOCS_VERSION=0.19.0   # no apt/installer-script; pinned release tarball
+TFLINT_VERSION=0.63.1           # pinned binary; its install script is deprecated
 
-# pre-commit (latest) and ansible (pinned) via pipx. Idempotent.
+# pre-commit (latest) and ansible-core (pinned) via pipx. Idempotent.
 install_pipx_tools() {
   if ! command -v pipx >/dev/null 2>&1; then
     echo "infra/install.sh: pipx not found — run python/install.sh first" >&2
     exit 1
   fi
   pipx install pre-commit 2>/dev/null || pipx upgrade pre-commit || true
-  pipx install "ansible==${ANSIBLE_VERSION}" 2>/dev/null \
-    || pipx install --force "ansible==${ANSIBLE_VERSION}" || true
+  pipx install "ansible-core==${ANSIBLE_CORE_VERSION}" 2>/dev/null \
+    || pipx install --force "ansible-core==${ANSIBLE_CORE_VERSION}" || true
 }
 
 if [[ "$OS" == "Darwin" ]]; then
@@ -38,10 +41,22 @@ if [[ "$OS" == "Darwin" ]]; then
 elif [[ "$OS" == "Linux" ]]; then
   arch="$(dpkg --print-architecture)"   # amd64 | arm64
 
-  # tflint, tfsec, trivy: official install scripts (fetch latest, install to
-  # /usr/local/bin). These are remote-script pipes — the documented install path.
-  curl -fsSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-  curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+  # tflint: pinned release binary. (Its install_linux.sh is deprecated — it warns
+  # it will be removed and advises against running unpinned downloaded scripts.)
+  tmp_tf="$(mktemp -d)"
+  curl -fsSL "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${arch}.zip" \
+    -o "${tmp_tf}/tflint.zip"
+  unzip -q "${tmp_tf}/tflint.zip" -d "$tmp_tf"
+  sudo install -m 0755 "${tmp_tf}/tflint" /usr/local/bin/tflint
+  rm -rf "$tmp_tf"
+
+  # tfsec: best-effort. It's archived (folded into Trivy) and its release assets are
+  # unreliable (e.g. no arm64), so a failure here must NOT abort the rest of infra —
+  # trivy below is the supported successor.
+  curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash \
+    || echo "infra/install.sh: tfsec install failed (deprecated — Trivy covers it); skipping" >&2
+
+  # trivy: official install script (install to /usr/local/bin).
   curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
     | sudo sh -s -- -b /usr/local/bin
 

--- a/script/packages/ubuntu.sh
+++ b/script/packages/ubuntu.sh
@@ -60,7 +60,7 @@ install_github_cli_repo() {
 }
 
 install_hashicorp_repo() {
-  log "Installing HashiCorp tools (terraform, vault, nomad, consul) from HashiCorp's apt repo"
+  log "Installing HashiCorp tools (terraform, vault, nomad, consul, packer) from HashiCorp's apt repo"
   if [ ! -f /usr/share/keyrings/hashicorp-archive-keyring.gpg ]; then
     wget -qO- https://apt.releases.hashicorp.com/gpg \
       | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
@@ -68,9 +68,10 @@ install_hashicorp_repo() {
   echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com ${CODENAME} main" \
     | sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
   sudo apt-get update -qq
-  # These are used as CLI clients (VAULT_ADDR/NOMAD_ADDR point at remote servers);
-  # we install the binaries but do not enable any systemd services.
-  sudo apt-get install -y -qq terraform vault nomad consul
+  # terraform/vault/nomad/consul are used as CLI clients (VAULT_ADDR/NOMAD_ADDR
+  # point at remote servers); we install the binaries but do not enable services.
+  # packer is the infra topic's only HashiCorp-repo tool (rest of infra is in infra/install.sh).
+  sudo apt-get install -y -qq terraform vault nomad consul packer
 }
 
 install_aws_cli_v2() {


### PR DESCRIPTION
**Stacked on PR2C.** Audit found the Terraform quality toolchain in heavy use but undocumented. Add an `infra/` topic: tflint/tfsec/trivy/terraform-docs/packer/pre-commit/ansible. macOS via Homebrew (incl. terraform-linters tap for tflint); Ubuntu via official install scripts (tflint/tfsec/trivy), pinned tarball (terraform-docs), pipx (pre-commit/ansible), and packer folded into ubuntu.sh's HashiCorp apt helper. Both tfsec and trivy installed (migration window). Not yet wired into bin/dot. Unrun on Linux.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code). Each commit carries an `agent-notes` self-review (read with `agent-review <base>..HEAD` on the branch).