### PR TITLE
PR2E: jvm/php/ios topics — ready-to-work ecosystems

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -83,5 +83,19 @@ brew "yarn"
 brew "pyenv"
 brew "pipx"
 
+# JVM (JDK 17 — Gradle 8.x / Android)
+brew "openjdk@17"
+
+# PHP (modern line — eRegulations; legacy PHP stays Dockerized)
+brew "php@8.2"
+brew "composer"
+
+# iOS (macOS only). Xcode.app is Mac App Store; Fastlane is per-repo via Bundler.
+brew "cocoapods"
+brew "swiftlint"
+
+# .NET SDK is opt-in / niche (modern cross-platform tools only) — install on demand:
+#   brew install --cask dotnet-sdk
+
 # git
 brew "git-lfs"

--- a/ios/install.sh
+++ b/ios/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+#
+# iOS toolchain — macOS only (see docs/package-matrix.md). Installs the Command
+# Line Tools, CocoaPods, and SwiftLint. Xcode.app itself comes from the Mac App
+# Store and is not scripted here; Fastlane is per-repo via Bundler. No-ops on Linux.
+
+set -e
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "ios/install.sh: macOS only — skipping on $(uname)"
+  exit 0
+fi
+
+# Command Line Tools. xcode-select --install opens a GUI prompt; non-fatal if
+# already installed.
+if ! xcode-select -p >/dev/null 2>&1; then
+  xcode-select --install || true
+  echo "Finish the Command Line Tools install in the macOS prompt, then re-run."
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "ios/install.sh: Homebrew missing; run homebrew/install.sh first" >&2
+  exit 1
+fi
+
+brew install cocoapods swiftlint
+
+echo "Install Xcode.app from the Mac App Store for full iOS builds; Fastlane is per-repo via Bundler."

--- a/jvm/install.sh
+++ b/jvm/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+#
+# JDK 17 for JVM / Android builds (see docs/package-matrix.md). Gradle bootstraps
+# per-repo via the wrapper; this provides the system JDK it needs (17+).
+# Independently runnable and safe to re-run. JAVA_HOME is set in zsh/zshrc.symlink
+# when a JDK 17 is present.
+
+set -e
+
+OS="$(uname)"
+
+if [[ "$OS" == "Darwin" ]]; then
+  if command -v brew >/dev/null 2>&1; then
+    brew install openjdk@17
+  else
+    echo "jvm/install.sh: Homebrew missing; run homebrew/install.sh first" >&2
+    exit 1
+  fi
+elif [[ "$OS" == "Linux" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq openjdk-17-jdk
+else
+  echo "jvm/install.sh: unsupported OS '$OS'" >&2
+  exit 1
+fi
+
+echo "JDK 17 installed. Open a new shell so JAVA_HOME is picked up."

--- a/php/install.sh
+++ b/php/install.sh
@@ -17,6 +17,9 @@ if [[ "$OS" == "Darwin" ]]; then
   fi
 elif [[ "$OS" == "Linux" ]]; then
   export DEBIAN_FRONTEND=noninteractive
+  # PHP 8.2 isn't in Ubuntu 24.04 (noble ships 8.3); the ondrej/php PPA provides it.
+  sudo apt-get install -y -qq software-properties-common
+  sudo add-apt-repository -y ppa:ondrej/php
   sudo apt-get update -qq
   sudo apt-get install -y -qq \
     php8.2 php8.2-cli php8.2-common php8.2-mbstring php8.2-xml php8.2-curl php8.2-mysql unzip

--- a/php/install.sh
+++ b/php/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env zsh
+#
+# PHP 8.2 + Composer (see docs/package-matrix.md). Targets the modern,
+# actively-maintained line (eRegulations / Craft CMS 4 pins 8.2); legacy PHP apps
+# stay Dockerized. Independently runnable and safe to re-run.
+
+set -e
+
+OS="$(uname)"
+
+if [[ "$OS" == "Darwin" ]]; then
+  if command -v brew >/dev/null 2>&1; then
+    brew install php@8.2 composer
+  else
+    echo "php/install.sh: Homebrew missing; run homebrew/install.sh first" >&2
+    exit 1
+  fi
+elif [[ "$OS" == "Linux" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq \
+    php8.2 php8.2-cli php8.2-common php8.2-mbstring php8.2-xml php8.2-curl php8.2-mysql unzip
+
+  # Composer via the official installer, with the signature check it recommends.
+  if ! command -v composer >/dev/null 2>&1; then
+    expected="$(curl -fsSL https://composer.github.io/installer.sig)"
+    curl -fsSL https://getcomposer.org/installer -o /tmp/composer-setup.php
+    actual="$(php -r "echo hash_file('sha384', '/tmp/composer-setup.php');")"
+    if [[ "$expected" == "$actual" ]]; then
+      sudo php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+    else
+      echo "php/install.sh: composer installer checksum mismatch — skipping composer" >&2
+    fi
+    rm -f /tmp/composer-setup.php
+  fi
+else
+  echo "php/install.sh: unsupported OS '$OS'" >&2
+  exit 1
+fi

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -68,6 +68,17 @@ if command -v pyenv >/dev/null 2>&1; then
   eval "$(pyenv init - zsh)"
 fi
 
+# Java (JDK 17). Homebrew openjdk is keg-only, so point JAVA_HOME at it; on Ubuntu
+# use the apt JDK path. `unsetopt nomatch` above keeps the glob safe when absent.
+for _jdk in /opt/homebrew/opt/openjdk@17 /usr/local/opt/openjdk@17 /usr/lib/jvm/java-17-openjdk-*; do
+  if [ -d "$_jdk" ]; then
+    export JAVA_HOME="$_jdk"
+    export PATH="$JAVA_HOME/bin:$PATH"
+    break
+  fi
+done
+unset _jdk
+
 if [ -d /opt/homebrew/opt ]; then
   export PATH="/opt/homebrew/bin:/opt/homebrew/opt/openssl@1.1/bin:$PATH"
   export PATH="/opt/homebrew/sbin:$PATH"


### PR DESCRIPTION
**Stacked on PR2D.** Second audit + 'machine ready to work' scope. Add three topics: `jvm/` (JDK 17 + JAVA_HOME), `php/` (PHP 8.2 + Composer, with signature-checked installer on Linux), `ios/` (macOS-only: CLT + cocoapods + swiftlint; Xcode.app is Mac App Store, Fastlane per-repo). Brewfile gains openjdk@17/php@8.2/composer/cocoapods/swiftlint; .NET SDK left as documented opt-in. Not yet wired into bin/dot. Unrun.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code). Each commit carries an `agent-notes` self-review (read with `agent-review <base>..HEAD` on the branch).