### PR TITLE
PR3: Wire bin/dot as a full OS-aware flow; Docker/DB per-OS

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -2,37 +2,48 @@
 #
 # dot
 #
-# `dot` handles installation, updates, things like that. Run it periodically
-# to make sure you're on the latest and greatest.
-export DOTHOME=$HOME/.dotfiles
+# Installs and updates everything. Run it periodically to stay current. OS-aware:
+# macOS uses Homebrew; Ubuntu uses apt / vendor repos / official binaries (see
+# docs/package-matrix.md). Each topic installer branches per-OS internally and is
+# safe to re-run, so this is just the ordered orchestration.
+export DOTHOME="$HOME/.dotfiles"
 
 DISTRO=$(uname)
-case $DISTRO in
-  'Linux')
-    sudo apt-get update
-    sudo apt-get -y -q upgrade
-    ;;
-  'Darwin')
-    # Set OS X defaults
-    sh $DOTHOME/osx/set-defaults.sh
-    # Install/upgrade nodes
-    sh $DOTHOME/node/install.sh 2>&1
-    # Install/upgrade homebrew packages
-    echo "Homebrew update"
-    sh $DOTHOME/homebrew/install.sh 2>&1
-    echo "Docker update"
-    sh $DOTHOME/docker/install.sh 2>&1
-    # Install/upgrade rubies
-    echo "Ruby update"
-    sh $DOTHOME/ruby/install.sh 2>&1
-    # Symlink databases
-    echo "Database(s) update"
-    sh $DOTHOME/databases/install.sh 2>&1
-    ;;
-  *)
-    echo "Good luck with that"
-    ;;
-esac
 
-# Install vim bundles
-$DOTHOME/vim/install.sh 2>&1
+# Run a step with a heading. Topic installers carry their own shebang (zsh), so
+# invoke them with the right interpreter rather than `sh` (which mis-runs zsh
+# array logic). Failures are reported but do not abort the rest.
+run() {
+  label=$1
+  shift
+  echo
+  echo "==> ${label}"
+  "$@" 2>&1 || echo "!! ${label} step failed (continuing)"
+}
+
+# OS-native package layer (Homebrew on macOS; apt/vendor/binary on Ubuntu).
+run "Packages" bash "$DOTHOME/script/install-packages"
+
+# macOS desktop defaults.
+if [ "$DISTRO" = "Darwin" ]; then
+  run "macOS defaults" sh "$DOTHOME/osx/set-defaults.sh"
+fi
+
+# Language runtimes + topic installers. Order matters: python before infra
+# (infra's pre-commit/ansible install via pipx from the managed Python).
+run "Ruby"      zsh "$DOTHOME/ruby/install.sh"
+run "Python"    zsh "$DOTHOME/python/install.sh"
+run "Node"      zsh "$DOTHOME/node/install.sh"
+run "Infra"     zsh "$DOTHOME/infra/install.sh"
+run "JVM"       zsh "$DOTHOME/jvm/install.sh"
+run "PHP"       zsh "$DOTHOME/php/install.sh"
+run "Docker"    zsh "$DOTHOME/docker/install.sh"
+run "Databases" zsh "$DOTHOME/databases/install.sh"
+
+# macOS-only iOS toolchain.
+if [ "$DISTRO" = "Darwin" ]; then
+  run "iOS" zsh "$DOTHOME/ios/install.sh"
+fi
+
+# Vim bundles (both OSes).
+run "Vim" sh "$DOTHOME/vim/install.sh"

--- a/bin/dot
+++ b/bin/dot
@@ -12,13 +12,18 @@ DISTRO=$(uname)
 
 # Run a step with a heading. Topic installers carry their own shebang (zsh), so
 # invoke them with the right interpreter rather than `sh` (which mis-runs zsh
-# array logic). Failures are reported but do not abort the rest.
+# array logic). A failed step is recorded and reported at the end, but does not
+# abort the rest — so one broken installer doesn't block the others.
+failed_steps=""
 run() {
   label=$1
   shift
   echo
   echo "==> ${label}"
-  "$@" 2>&1 || echo "!! ${label} step failed (continuing)"
+  if ! "$@" 2>&1; then
+    echo "!! ${label} step failed (continuing)"
+    failed_steps="${failed_steps} ${label}"
+  fi
 }
 
 # OS-native package layer (Homebrew on macOS; apt/vendor/binary on Ubuntu).
@@ -47,3 +52,14 @@ fi
 
 # Vim bundles (both OSes).
 run "Vim" sh "$DOTHOME/vim/install.sh"
+
+echo
+if [ -n "$failed_steps" ]; then
+  echo "!! Some steps failed:${failed_steps}"
+  echo "   Re-run 'dot', check the output above, or run 'script/doctor' to see what's missing."
+else
+  echo "All steps completed."
+fi
+# Final status (sourcing-safe — no 'exit', so bootstrap's 'if source bin/dot' still works):
+# 0 when every step succeeded, 1 when any step failed.
+[ -z "$failed_steps" ]

--- a/databases/install.sh
+++ b/databases/install.sh
@@ -1,11 +1,27 @@
 #!/usr/bin/env zsh
+#
+# Databases (see docs/package-matrix.md). macOS: force-link the Homebrew mysql/
+# postgresql for their headers. Ubuntu: apt packages (mysql/postgresql/redis/
+# memcached) under systemd. In practice apps run these via Docker Compose; this
+# is for local tooling/clients. Independently runnable, safe to re-run.
 
-BREW_COMMAND=$(which brew)
+set -e
 
-echo
-echo "Force linking mysql and postgresql for their respective headers"
-echo
-${BREW_COMMAND} link --force --overwrite mysql@5.7
-${BREW_COMMAND} link --force --overwrite postgresql
+OS="$(uname)"
 
-exit 0
+if [[ "$OS" == "Darwin" ]]; then
+  brew_command="$(which brew)"
+  echo "Force linking mysql and postgresql for their respective headers"
+  ${brew_command} link --force --overwrite mysql@5.7 || true
+  ${brew_command} link --force --overwrite postgresql || true
+
+elif [[ "$OS" == "Linux" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq mysql-server postgresql redis-server memcached
+  echo "Installed mysql/postgresql/redis/memcached via apt (systemd-managed)."
+
+else
+  echo "databases/install.sh: unsupported OS '$OS'" >&2
+  exit 1
+fi

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,18 +1,44 @@
 #!/usr/bin/env zsh
 #
-# Docker for Mac
-#
+# Docker (see docs/package-matrix.md). macOS: Docker Desktop (cask). Ubuntu:
+# Docker Engine from Docker's official apt repo. Independently runnable, idempotent.
 
-BREW_COMMAND=$(which brew)
+set -e
 
-# Check for Homebrew
-if test ! $(which brew)
-then
-    echo "Please install Homebrew first."
-    echo
-    echo "See: homebrew/install.sh"
+OS="$(uname)"
+
+if [[ "$OS" == "Darwin" ]]; then
+  if command -v brew >/dev/null 2>&1; then
+    brew install --cask docker
+  else
+    echo "docker/install.sh: Homebrew missing; run homebrew/install.sh first" >&2
+    exit 1
+  fi
+
+elif [[ "$OS" == "Linux" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+
+  # Docker's official apt repo.
+  sudo install -m 0755 -d /etc/apt/keyrings
+  if [ ! -f /etc/apt/keyrings/docker.asc ]; then
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+  fi
+  # shellcheck source=/dev/null  # system file, present only on the target host
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq \
+    docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+  # Run docker without sudo. Group membership takes effect on next login.
+  if ! id -nG "$USER" | tr ' ' '\n' | grep -qx docker; then
+    sudo usermod -aG docker "$USER"
+    echo "Added $USER to the 'docker' group — log out and back in for it to take effect."
+  fi
+
+else
+  echo "docker/install.sh: unsupported OS '$OS'" >&2
+  exit 1
 fi
-
-${BREW_COMMAND} install docker --cask
-
-exit 0


### PR DESCRIPTION
**Stacked on #15 (PR2E).** Makes the stack runnable end-to-end. `bin/dot` becomes one OS-aware orchestrator: package layer → macOS defaults (mac) → ruby → python → node → infra → jvm → php → docker → databases → ios (mac) → vim, each in its correct interpreter (fixes the old `sh`-runs-zsh bug). `docker/install.sh` and `databases/install.sh` gain Ubuntu branches (Docker Engine apt repo + docker group; apt mysql/postgres/redis/memcached).

⚠️ **Known, owned by PR4 (runtime modernization):** on Ubuntu, ruby (Homebrew openssl@1.1 paths) and node (no nvm-on-Linux) steps won't succeed yet. Everything else is wired. Full run is unexecuted — needs an Ubuntu VM / fresh Mac.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code). Each commit carries an `agent-notes` self-review (`agent-review <base>..HEAD`).