### PR TITLE
PR6: Docs — README rewrite, CONTRIBUTING, PHASE2-DESKTOP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+These dotfiles are **one shared repo the whole team tracks**. The golden rule:
+
+> **If a change helps only you, put it in a `.local` file. If it helps the team, open a PR.**
+
+## Local change vs. shared change
+
+- **Just for you** → an untracked `.local` file (`~/.zshrc.local`, `~/.gitconfig.local`,
+  `~/.tmux.conf.local`, `~/.vimrc.local`). These are sourced automatically and survive
+  `git pull`. Never edit a tracked `*.symlink`/`*.zsh` file for a personal preference.
+- **For everyone** → a branch and a PR against this repo.
+
+## Repo conventions
+
+Everything is organized by **topic** (one directory per area). Within a topic:
+
+- `*.zsh` — auto-sourced into the shell. Aliases, exports, functions, completions.
+- `*.symlink` — symlinked into `$HOME` without the extension when `bootstrap` runs.
+- `install.sh` — run by `bin/dot` to install the topic's dependencies. **Must branch
+  per-OS** (`case "$(uname)"` → Darwin / Linux) and be **idempotent** (safe to re-run).
+- `bin/` — scripts here are on `$PATH`.
+
+### Adding a new topic
+
+1. Create the directory (e.g. `rust/`).
+2. Add `*.zsh` for shell config, `*.symlink` for dotfiles, `install.sh` for dependencies.
+3. If it adds a tool, **add a row to [`docs/package-matrix.md`](docs/package-matrix.md)
+   in the same PR** (see below).
+4. Wire `install.sh` into `bin/dot` in the right order if it should run on `dot`.
+
+## The package matrix is the contract
+
+[`docs/package-matrix.md`](docs/package-matrix.md) records, for every shared tool: the
+capability, how it's installed on macOS, how on Ubuntu, which topic owns it, and how
+closely versions must track. **A PR that adds, removes, or moves a tool must update the
+matrix in the same PR.** A drift between the matrix and the installers is a bug.
+
+Ground rules the matrix encodes:
+
+- macOS uses **Homebrew**; Ubuntu uses **apt** → **vendor apt repo** → **official binary
+  installer**, in that order of preference.
+- **Homebrew-on-Linux only as an explicit exception**, when no native path exists.
+- Language runtimes stay in their topic installers (chruby/ruby-install, nvm, pyenv).
+- Prefer boring OS-native defaults over cross-platform cleverness.
+- Installers may upgrade packages but **must not overwrite user-owned config without an
+  explicit prompt**.
+
+## Quality bar
+
+- **shellcheck** your scripts (`shellcheck script/foo`). zsh-shebang installers can't be
+  shellchecked cleanly — gate those on `zsh -n`.
+- Run **`script/doctor`** after your change to confirm nothing regressed.
+- **Test on both platforms** before merging anything OS-specific: macOS (Apple Silicon)
+  and an **Ubuntu 24.04 VM**. The matrix promises parity; prove it.
+- Keep PRs small and focused. One topic / one concern per PR.
+
+## PR flow
+
+```sh
+cd ~/.dotfiles
+git checkout -b my-change
+# ... edit tracked files, update docs/package-matrix.md if needed ...
+shellcheck script/...        # and/or zsh -n on zsh installers
+./script/doctor              # sanity check
+git commit && git push -u origin my-change
+gh pr create
+```
+
+## Updating your machine
+
+```sh
+cd ~/.dotfiles && git pull && bin/dot && script/doctor
+```

--- a/PHASE2-DESKTOP.md
+++ b/PHASE2-DESKTOP.md
@@ -1,0 +1,45 @@
+# Phase 2 — Linux desktop (Hyprland)
+
+**Status: deferred. Not implemented.** This document captures the plan so it isn't lost;
+no desktop config ships in the repo yet.
+
+## Why it's separate
+
+The current dotfiles bring a **developer environment** to parity across macOS and Ubuntu.
+A desktop layer is different in kind: it's **Linux-only** (macOS supplies its own window
+manager — Aqua), so it has no macOS counterpart and doesn't fit the two-column package
+matrix. It's a net-new topic area, sequenced after the dev-environment work is verified.
+
+Tommy is standing up an **Ubuntu 24.04 LTS + Hyprland** machine; this is the target.
+
+## Target stack (grounded, ~2026)
+
+Hyprland is deliberately *not a desktop environment* — you assemble the pieces. Config
+lives under `~/.config/<tool>/`.
+
+| Component | Choice | Notes |
+|---|---|---|
+| Compositor | **Hyprland** | Not in 24.04 apt; install via the **cpiber PPA** (`ppa:cppiber/hyprland`, ships 0.54.x for noble), or the JaKooLit `Ubuntu-Hyprland` installer (24.04 branch). |
+| Status bar | **Waybar** | `~/.config/waybar/{config,style.css}` |
+| App launcher | **fuzzel** (or wofi) | Wayland-native |
+| Terminal | **kitty** (ghostty rising; foot for minimal) | `~/.config/kitty/kitty.conf` |
+| Notifications | **mako** | `~/.config/mako/config` |
+| Clipboard | **wl-clipboard** + **cliphist** | already used by `system/clipboard.zsh` |
+| Screenshots | **hyprshot** (wraps grim+slurp) | bound in `hyprland.conf` |
+| Idle / lock | **hypridle** + **hyprlock** | |
+| Wallpaper | **hyprpaper** (static) or **swww** (animated) | |
+| Output/display | `monitor=` lines; **nwg-displays** for a GUI | |
+
+## Gotchas
+
+- 24.04 ships GNOME/Wayland; Hyprland coexists as a separate session.
+- The base repo's `wayland-protocols`/deps are too old to build Hyprland from source — the
+  PPA carries the newer deps. Building from source is discouraged for general use.
+- NVIDIA needs extra Wayland env vars.
+
+## When this gets built
+
+It becomes a new topic area (e.g. `hypr/` with `hyprland.conf.symlink`, plus `waybar/`,
+`kitty/`, etc.), Linux-guarded so it no-ops on macOS, with its own `install.sh` using the
+cpiber PPA. Add the desktop tools to `docs/package-matrix.md` as Linux-only rows (macOS =
+n/a) when that happens.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,91 @@
-## dotfiles
+# Kalkomey dotfiles
 
-Kalkomey's dotfiles based on [Zach Holman](https://github.com/holman)'s [dotfiles](https://github.com/holman/dotfiles) philosophy. However, there's plenty of stuff from [Hashrocket](https://github.com/hashrocket)'s [dotmatrix](https://github.com/hashrocket/dotmatrix).
+A **ready-to-work Kalkomey developer machine** on macOS (Apple Silicon) and Ubuntu
+24.04. One clone, one bootstrap, and you have the shell, tools, runtimes, and config the
+team uses. Based on [Zach Holman](https://github.com/holman)'s
+[dotfiles](https://github.com/holman/dotfiles) and Hashrocket's
+[dotmatrix](https://github.com/hashrocket/dotmatrix), adapted into a shared, centrally
+managed repo.
 
-## install
+This is **one shared repo everyone tracks** — not a personal fork. Tweaks that are just
+for you go in untracked `.local` files; changes for the whole team go through a PR. See
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
-Run this:
+## Install
 
 ```sh
-git clone https://github.com/kalkomey/dotfiles.git ~/.dotfiles
+git clone git@github.com:kalkomey/dotfiles.git ~/.dotfiles
 cd ~/.dotfiles
 script/bootstrap
 ```
 
-This will symlink the appropriate files in `.dotfiles` to your home directory.
-Everything is configured and tweaked within `~/.dotfiles`.
+`bootstrap` sets up your git identity and SSH key, symlinks the config files into your
+home directory, and then runs `bin/dot` to install everything.
 
-The main file you'll want to change right off the bat is `zsh/zshrc.symlink`,
-which sets up a few paths that'll be different on your particular machine.
+## The three commands
 
-`dot` is a simple script that installs some dependencies, sets sane OS X
-defaults, and so on. Tweak this script, and occasionally run `dot` from
-time to time to keep your environment fresh and up-to-date. You can find
-this script in `bin/`.
+| Command | What it does |
+|---|---|
+| `script/bootstrap` | One-time setup: git identity, SSH key, symlinks, then `dot`. |
+| `bin/dot` | Install/update everything. **Run it periodically** to stay current. OS-aware: Homebrew on macOS, apt/vendor repos on Ubuntu. |
+| `script/doctor` | Report what's installed vs. missing. **Never installs or fixes** — just tells you if your machine is ready. |
 
-## custom install
+## How it works
 
-If you are using an alternative shell like fish, or alternative version manager software like asdf, some of the commands might not be a good fit for you. You might also want to ignore certain aliases or osx configuration changes to fit your preferences. As a bare minimum you will need to have the `.dotfiles/bin` files in your path to set up a lot of repositories. You can accomplish this by cloning the repository and using whatever method your shell supports to add that folder to your path, for example `fish_add_path .dotfiles/bin`. You might also need some of the workarounds like the ones for mysql described in `ruby/install.sh`.
+Everything is organized by **topic** — one directory per area (`git/`, `tmux/`, `ruby/`,
+`infra/`, …). Within a topic:
 
-## topical
+- `*.zsh` files are **auto-sourced** into your shell (aliases, config, functions).
+- `*.symlink` files are **symlinked** into `$HOME` without the extension
+  (`git/gitconfig.symlink` → `~/.gitconfig`).
+- `install.sh` is run by `dot` to install that topic's dependencies; it branches per-OS.
+- `bin/` is on your `$PATH`, so its scripts are available as commands.
 
-Everything's built around topic areas. If you're adding a new area to your
-forked dotfiles — say, "Java" — you can simply add a `java` directory and put
-files in there. Anything with an extension of `.zsh` will get automatically
-included into your shell. Anything with an extension of `.symlink` will get
-symlinked without extension into `$HOME` when you run `script/bootstrap`.
+Which tool comes from where (Homebrew vs apt vs a vendor repo vs a binary installer) is
+documented in **[docs/package-matrix.md](docs/package-matrix.md)** — the shared contract.
+Parity is by capability, not by package manager: macOS uses Homebrew; Ubuntu uses
+apt / vendor apt repos / official installers. A few capabilities are macOS-only (iOS), and
+some legacy stacks are deliberately out of scope — all recorded in the matrix.
 
-## what's inside
+Cross-OS niceties are handled for you: clipboard access (`pbcopy`/`pbpaste`, the `pubkey`
+helper, tmux copy) works the same via `system/clipboard.zsh` (native on macOS,
+`wl-clipboard` on Wayland, `xclip` on X11).
 
-A lot of what's inside is just aliases: `gst` for `git status`, `gpr` for `git
-pull --rebase --prune`, for example. You can browse the `aliases.zsh` files in
-each topic directory. There's also a collection of scripts in `bin` you can
-browse.
+## Where your personal changes go
 
-## thanks
+**If a change helps only you, put it in a `.local` file. If it helps the team, open a
+PR.** The `.local` files are untracked and sourced automatically, so they survive
+`git pull`:
 
-I forked [Zach Holman](http://github.com/holman)'s
-[dotfiles](http://github.com/holman/dotfiles) and basically adopted his philosophy
-but made it work with my preferred environment tools.
-A decent amount of the code in these dotfiles stems either from Hashrocket's Dotmatrix, Holman's dotfiles or by extension,
-Ryan Bates' original dotfiles.
+| File | For |
+|---|---|
+| `~/.zshrc.local` | Personal shell exports, aliases, paths, prompt tweaks |
+| `~/.gitconfig.local` | Your git identity and personal git preferences |
+| `~/.tmux.conf.local` | Personal tmux overrides |
+| `~/.vimrc.local` | Personal vim overrides |
+| `.mux` (per project) | Project tmux session layout |
+
+Don't edit the tracked `*.symlink`/`*.zsh` files for personal preferences — that's what
+`.local` is for. Editing tracked files is for changes you intend to PR for everyone.
+
+## Staying current
+
+```sh
+cd ~/.dotfiles && git pull && bin/dot && script/doctor
+```
+
+## Contributing
+
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** — how to make a local change vs. a shared
+change, the topic conventions, the package-matrix contract, and the PR flow.
+
+## Linux desktop (Phase 2)
+
+A Hyprland/Wayland desktop layer for Ubuntu is planned but **not yet built** — see
+**[PHASE2-DESKTOP.md](PHASE2-DESKTOP.md)**.
+
+## Thanks
+
+Forked from [Zach Holman](http://github.com/holman)'s
+[dotfiles](http://github.com/holman/dotfiles); much also stems from Hashrocket's Dotmatrix
+and, by extension, Ryan Bates' original dotfiles.


### PR DESCRIPTION
**Stacked on #18 (PR5). Final planned slice.** Makes the repo legible and contributable.

- **README** reframed from a personal fork-it repo to a *ready-to-work shared machine* (macOS + Ubuntu): the three commands (bootstrap/dot/doctor), topical structure, the **.local override model** (local change vs team change), the package-matrix contract, cross-OS clipboard, staying current. Drops the old "edit zshrc.symlink right off the bat" guidance.
- **CONTRIBUTING.md** — golden rule (.local vs PR), topic conventions, how to add a topic, the matrix-in-same-PR rule, OS-guard + idempotency expectations, the shellcheck/doctor/both-platforms quality bar, PR flow.
- **PHASE2-DESKTOP.md** — the deferred Ubuntu Hyprland stack, documented not built.

Two links (docs/package-matrix.md, system/clipboard.zsh) live on sibling PR branches and resolve once the stack merges to master. This rewrite supersedes PR1's small README note (expect a trivial conflict resolved in favor of this).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code). Each commit carries an `agent-notes` self-review (`agent-review <base>..HEAD`).